### PR TITLE
Add `tests` directory

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# tests
+
+This directory includes various system and unit tests for the Bruin Assistant extension. Each subdirectory contains tests dedicated to a certain portion/feature of the extension.


### PR DESCRIPTION
Adds a `tests` directory as instructed by the Part B specification document. Subdirectories in this directory will be dedicated to holding tests for each portion/feature of our extension.